### PR TITLE
Cash address format check error fix

### DIFF
--- a/src/components/bch-send/send-card.js
+++ b/src/components/bch-send/send-card.js
@@ -263,7 +263,7 @@ class SendCard extends React.Component {
       const bchjs = wallet.bchjs
 
       // If the address is an SLP address, convert it to a cash address.
-      if (!bchAddr.includes(bchAddr)) {
+      if (!bchAddr.includes('bitcoincash:')) {
         bchAddr = bchjs.SLP.Address.toCashAddress(bchAddr)
       }
 


### PR DESCRIPTION
The check for cash address format does not seems to be right. It should check the prefix, not to compare the address to itself.